### PR TITLE
Auth flow

### DIFF
--- a/strikecircle/static/strikecircle/sass/base_template.sass
+++ b/strikecircle/static/strikecircle/sass/base_template.sass
@@ -1,6 +1,6 @@
 @import "../../../../static/bulma/sass/style.sass"
 
-body
+html
   background-color: $light
   color: $dark
 

--- a/strikecircle/templates/strikecircle/base_form.html
+++ b/strikecircle/templates/strikecircle/base_form.html
@@ -1,4 +1,4 @@
-{% extends 'strikecircle/base_template.html' %}
+{% extends 'base_template.html' %}
 {% load bulma_tags %}
 
 {% block subtitle %}{{ title }}{% endblock subtitle %}

--- a/strikecircle/templates/strikecircle/dashboard.html
+++ b/strikecircle/templates/strikecircle/dashboard.html
@@ -1,4 +1,4 @@
-{% extends 'strikecircle/base_template.html' %}
+{% extends 'base_template.html' %}
 {% load sass_tags %}
 
 {% block subtitle %}Dashboard{% endblock %}

--- a/strikecircle/templates/strikecircle/pledge_form.html
+++ b/strikecircle/templates/strikecircle/pledge_form.html
@@ -1,4 +1,4 @@
-{% extends 'strikecircle/base_template.html' %}
+{% extends 'base_template.html' %}
 {% load bulma_tags %}
 {% load static %}
 {% load sass_tags %}

--- a/strikecircle/templates/strikecircle/pledge_list.html
+++ b/strikecircle/templates/strikecircle/pledge_list.html
@@ -1,4 +1,4 @@
-{% extends 'strikecircle/base_template.html' %}
+{% extends 'base_template.html' %}
 {% load static %}
 {% load sass_tags %}
 

--- a/strikecircle/templates/strikecircle/program_guide.html
+++ b/strikecircle/templates/strikecircle/program_guide.html
@@ -1,4 +1,4 @@
-{% extends 'strikecircle/base_template.html' %}
+{% extends 'base_template.html' %}
 {% load sass_tags %}
 
 {% block subtitle %}Program Guide{% endblock subtitle %}

--- a/strikecircle/templates/strikecircle/sc_edit_form.html
+++ b/strikecircle/templates/strikecircle/sc_edit_form.html
@@ -1,4 +1,4 @@
-{% extends 'strikecircle/base_template.html' %}
+{% extends 'base_template.html' %}
 {% load bulma_tags %}
 
 {% block subtitle %}Edit Strike Circle{% endblock subtitle %}

--- a/strikecircle/templates/strikecircle/signup_form.html
+++ b/strikecircle/templates/strikecircle/signup_form.html
@@ -1,4 +1,4 @@
-{% extends 'strikecircle/base_template.html' %}
+{% extends 'base_template.html' %}
 {% load bulma_tags %}
 
 {% block subtitle %}Log in{% endblock subtitle %}

--- a/strikecircle/urls.py
+++ b/strikecircle/urls.py
@@ -3,7 +3,7 @@ from django.shortcuts import redirect
 from django.urls import path
 from django.conf.urls.static import static
 
-from strikecircle.views import Dashboard, DataEntry, ProgramGuide, Signup, UpdateStrikeCircle
+from strikecircle.views import Dashboard, DataEntry, ProgramGuide, UpdateStrikeCircle
 
 app_name = 'strikecircle'
 urlpatterns = [
@@ -11,5 +11,4 @@ urlpatterns = [
     path('data-entry/', DataEntry.as_view(), name='data_entry_dash'),
     path('profile/', UpdateStrikeCircle.as_view(), name='sc_edit'),
     path('program-guide/', ProgramGuide.as_view(), name='program_guide'),
-    path('signup/', Signup.as_view(), name='signup')
 ]

--- a/sunrise/urls.py
+++ b/sunrise/urls.py
@@ -4,10 +4,12 @@ from django.shortcuts import redirect
 from django.urls import include, path
 from django.conf.urls.static import static
 
+from strikecircle.views import Signup
 
 urlpatterns = [
     path('', lambda r: redirect('strikecircle:dashboard')),
-    path('accounts/', include('django.contrib.auth.urls')),
     path('admin/', admin.site.urls),
-    path('pledge-to-vote/', include('strikecircle.urls')),
+    path('strike-circle/', include('strikecircle.urls')),
+    path('users/', include('django.contrib.auth.urls')),
+    path('users/signup/', Signup.as_view(), name='signup')
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/templates/base_template.html
+++ b/templates/base_template.html
@@ -17,7 +17,7 @@
     <nav class="navbar">
       <div class="navbar-brand">
         <a class="navbar-item" href="https://sunrisemovement.org/">
-          <img src="{% static 'strikecircle/sunrise_logo.png' %}" alt="Sunrise Movement: Pledge to Vote">
+          <img src="{% static 'strikecircle/sunrise_logo.png' %}" alt="Sunrise Movement: Strike Circles">
         </a>
       </div>
 
@@ -31,7 +31,12 @@
 
       <div class="navbar-end">
         <a class="navbar-item" href="{% url 'strikecircle:sc_edit' %}">Settings</a>
+        {% if request.user.is_authenticated %}
         <a class="navbar-item" href="{% url 'logout' %}">Log out</a>
+        {% else %}
+        <a class="navbar-item" href="{% url 'login' %}">Log in</a>
+        <a class="navbar-item" href="{% url 'signup' %}">Sign up</a>
+        {% endif %}
       </div>
 
       <div role="button" class="navbar-burger burger" aria-expanded="false" data-target="pledgeMenu">
@@ -40,6 +45,8 @@
         <span aria-hidden="true"></span>
         <span aria-hidden="true"></span>
         <span aria-hidden="true"></span>
+        {% comment %} Add an extra menu item if the user isn't authenticated, so that we can show log in and sign up options {% endcomment %}
+        {% if not request.user.is_authenticated %}<span aria-hidden="true"></span>{% endif %}
       </div>
     </nav>
   </div>

--- a/templates/registration/base.html
+++ b/templates/registration/base.html
@@ -1,0 +1,1 @@
+{% extends 'base_template.html' %}

--- a/templates/registration/logged_out.html
+++ b/templates/registration/logged_out.html
@@ -1,0 +1,7 @@
+{% extends "registration/base.html" %}
+{% load i18n %}
+
+{% block content %}
+  <p class="content">{% trans "Thanks for using the Sunrise Movement's Strike Circles site!" %}</p>
+  <p><a class="button is-success" href="{% url 'login' %}">{% trans 'Log in again' %}</a></p>
+{% endblock %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,21 @@
+{% extends "registration/base.html" %}
+{% load bulma_tags i18n %}
+
+{% block subtitle %}Login{% endblock subtitle %}
+
+{% block content %}
+
+  {% if form.errors %}
+    <p>{% trans "Your username and password didn't match. Please try again." %}</p>
+  {% endif %}
+
+  <form method="post" action="{% url 'login' %}">
+    {% csrf_token %}
+    {{ form|bulma }}
+    <div class="field">
+      <button type="submit" class="button is-primary">{% trans 'Log in' %}</button>
+    </div>
+    <input type="hidden" name="next" value="{% url 'strikecircle:dashboard' %}"/>
+  </form>
+
+{% endblock %}


### PR DESCRIPTION
Fixes #6. 

* Added login/signup links to navbar when not authenticated
* Overrode some of `django-bulma`'s registration templates to provide a more customized authentication experience.
* Moved `base_template.html` to the project-level `templates/` directory, since it's used across apps.